### PR TITLE
zmiana umiejscowienia streszczenia w dokumencie

### DIFF
--- a/xmgr.cls
+++ b/xmgr.cls
@@ -204,7 +204,8 @@ i~materialnych innych osób.\endgraf }
   \global\let\date\relax
   \global\let\and\relax
   %
-  \clearpage 
+  \thispagestyle{empty}
+  \cleardoublepage
   \thispagestyle{empty}
   \InsertAbstractHere
   \section*{Słowa kluczowe}


### PR DESCRIPTION
- w przypadku druku dwustronnego streszczenie pojawia się na trzeciej
  stronie
